### PR TITLE
fix: Updated release statuses for helm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Helm plugin to poll for a release status.
 As per the [Helm documentation](https://helm.sh/docs/helm/helm_status/), a release can have the following final states:
 
 ```go
-"UNKNOWN", "DEPLOYED", "DELETED", "SUPERSEDED", "FAILED"
+"unknown", "deployed", "deleted", "superseded", "failed"
 ```
 
 A final state means that the release does not have any ongoing operations, such as an upgrade.
@@ -84,7 +84,7 @@ helm poll -r codacy-nightly
   "Name": "codacy-nightly",
   "Revision": 47,
   "Updated": "Thu Jan 30 13:41:56 2020",
-  "Status": "DEPLOYED",
+  "Status": "deployed",
   "Chart": "codacy-0.5.0-NIGHTLY.30-01-2020",
   "AppVersion": "0.5.0-NIGHTLY.30-01-2020",
   "Namespace": "codacy-nightly"

--- a/poll.go
+++ b/poll.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-var statuses = [5]string{"UNKNOWN", "DEPLOYED", "DELETED", "SUPERSEDED", "FAILED"}
+var statuses = [5]string{"unknown", "deployed", "deleted", "superseded", "failed"}
 
 const (
 	mockReleaseName = "mockReleaseName"

--- a/poll.go
+++ b/poll.go
@@ -16,8 +16,8 @@ var statuses = [5]string{"unknown", "deployed", "deleted", "superseded", "failed
 
 const (
 	mockReleaseName = "mockReleaseName"
-	deployedState   = "DEPLOYED"
-	installingState = "INSTALLING"
+	deployedState   = "deployed"
+	installingState = "installing"
 	releaseStates   = "releaseStates"
 )
 
@@ -55,7 +55,7 @@ type ReleaseList []Release
 
 func (release Release) isAvailableStatus() bool {
 	for _, status := range statuses {
-		if release.Status == status {
+		if strings.ToLower(release.Status) == status {
 			return true
 		}
 	}
@@ -84,7 +84,7 @@ func pollRelease(runner Runner, releaseName string, timeout int, interval int) R
 		if (release != Release{}) && release.isAvailableStatus() {
 			return release
 		}
-		fmt.Println(fmt.Sprintf("%s is %s... waiting...", releaseName, release.Status))
+		fmt.Println(fmt.Sprintf("%s is %s... waiting...", releaseName, strings.ToLower(release.Status)))
 		time.Sleep(time.Duration(interval) * time.Second)
 	}
 	fmt.Println(fmt.Sprintf("%s took to long to become available... exiting...", releaseName))


### PR DESCRIPTION
This will allow our components to publish to codacy-dev (k8s) when they get published to cloud dev using helm3.